### PR TITLE
Fix git push in CI

### DIFF
--- a/scripts/retire.sh
+++ b/scripts/retire.sh
@@ -112,7 +112,7 @@ for login in *; do
       trap 'trace git checkout "$mainBranch" && trace git branch -D "$branchName"' exit
       trace git rm "$login"
       trace git commit -m "Automatic retirement of @$login"
-      effect git push -f -u git@github.com:"$ORG"/"$MEMBER_REPO" "$branchName"
+      effect git push -f -u origin "$branchName"
       {
         echo "This is an automated PR to retire @$login as a Nixpkgs committers due to not using their commit access for 1 year."
         echo ""


### PR DESCRIPTION
Using a direct URL doesn't work in CI, because there authentication works with a token that's associated with a specific named remote: https://github.com/NixOS/nixpkgs-committers/actions/runs/16507360310/job/46681315934

Assume the origin remote exists instead, which is generally what it would be locally, and is also what actions/checkout uses