### PR TITLE
Set @infinisil as code owner for everything but the member list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @NixOS/commit-bit-delegation
+* @infinisil
+/members @NixOS/commit-bit-delegation


### PR DESCRIPTION
We don't need to get the commit bit delegators involved for everything