### PR TITLE
scripts/retire: fix "created on reception" epoch

### DIFF
--- a/scripts/retire.sh
+++ b/scripts/retire.sh
@@ -60,7 +60,7 @@ newCutoff=$(date --date="1 year ago" +%s)
 # For now however, the code needs to check if the file creation date
 # is before 2025-07-09 to distinguish between periods A and C,
 # so we hardcode that date for the code to use.
-createdOnReceptionEpoch=$(date --date=2025-07-09 +%s)
+createdOnReceptionEpoch=$(date --date=2025-07-17 +%s)
 
 if [[ -z "${PROD:-}" ]]; then
   tmp=$(git rev-parse --show-toplevel)/.tmp


### PR DESCRIPTION
The epoch was set to when the [initial sync PR](https://github.com/NixOS/nixpkgs-committers/pull/1)'s commit was committed (2025-07-08), not when the merge commit merging the PR was committed (2025-07-16).

Since we are using `--first-parent`, we need the latter.

Fixes #38
