### PR TITLE
Implement retirement delay by closing PR

### DIFF
--- a/.github/workflows/retire.yml
+++ b/.github/workflows/retire.yml
@@ -37,8 +37,7 @@ jobs:
           # Fetch full history to determine when committers were added
           fetch-depth: 0
       - name: Run script
-        # One month plus a bit of leeway
-        run: scripts/retire.sh NixOS nixpkgs nixpkgs-committers members "yesterday 1 month ago"
+        run: scripts/retire.sh NixOS nixpkgs nixpkgs-committers members "yesterday 1 month ago" "1 year ago"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PROD: "1"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The PR will ping the user and inform them that it will by default be merged and 
 If the PR is still open one month later,
 an automated comment will be posted with the next steps for the Nixpkgs commit delegators.
 
+If the PR is closed, retirement is delayed by another year.
+
 ## Automation setup
 
 Automation depends on a GitHub App with the following permissions:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -72,40 +72,47 @@ The following sequence tests all code paths:
 
 1. Run the script with the `active` repo argument to simulate CI running without inactive users:
    ```bash
-   scripts/retire.sh infinisil-test-org active nixpkgs-committers members-test 'yesterday 1 month ago'
+   scripts/retire.sh infinisil-test-org active nixpkgs-committers members-test 'yesterday 1 month ago' now
    ```
 
    Check that no PR would be opened.
 2. Run the script with the `empty` repo argument to simulate CI running with inactive users:
 
    ```bash
-   scripts/retire.sh infinisil-test-org empty nixpkgs-committers members-test 'yesterday 1 month ago'
+   scripts/retire.sh infinisil-test-org empty nixpkgs-committers members-test 'yesterday 1 month ago' now
    ```
 
    Check that it would only create a PR for your own user and not the "new-committer-1" or "new-committer-2" user before running it again with `PROD=1` to actually do it:
 
    ```bash
-   PROD=1 scripts/retire.sh infinisil-test-org empty nixpkgs-committers members-test 'yesterday 1 month ago'
+   PROD=1 scripts/retire.sh infinisil-test-org empty nixpkgs-committers members-test 'yesterday 1 month ago' now
    ```
 
    Check that it created the PR appropriately, including assigning the "retirement" label.
    You can undo this step by closing the PR.
 3. Run it again to simulate CI running again later:
    ```bash
-   PROD=1 scripts/retire.sh infinisil-test-org empty nixpkgs-committers members-test 'yesterday 1 month ago'
+   PROD=1 scripts/retire.sh infinisil-test-org empty nixpkgs-committers members-test 'yesterday 1 month ago' now
    ```
    Check that no other PR is opened.
-4. Run it again with `now` as the date to simulate the time interval passing:
+4. Run it again with `now` as the notice cutoff date to simulate the time interval passing:
    ```bash
-   PROD=1 scripts/retire.sh infinisil-test-org empty nixpkgs-committers members-test now
+   PROD=1 scripts/retire.sh infinisil-test-org empty nixpkgs-committers members-test now now
    ```
    Check that it undrafted the previous PR and posted an appropriate comment.
 5. Run it again to simulate CI running again later:
    ```bash
-   PROD=1 scripts/retire.sh infinisil-test-org empty nixpkgs-committers members-test now
+   PROD=1 scripts/retire.sh infinisil-test-org empty nixpkgs-committers members-test now now
    ```
-6. Reset by marking the PR as a draft again.
-7. Run it again with the `active` repo argument to simulate activity during the time interval:
+   Check that no other PR is opened.
+6. Reset by marking the PR as a draft again, then run it again with the `active` repo argument to simulate activity during the time interval:
    ```bash
-   PROD=1 scripts/retire.sh infinisil-test-org active nixpkgs-committers members-test now
+   PROD=1 scripts/retire.sh infinisil-test-org active nixpkgs-committers members-test now now
    ```
+   Check that it gets undrafted with a comment listing the new activity.
+8. Close the PR, then run the script again with no activity and for an earlier close cutoff, simulating that the retirement was delayed:
+   ```bash
+   PROD=1 scripts/retire.sh infinisil-test-org empty nixpkgs-committers members-test now '1 day ago'
+   ```
+
+   Check that no other PR is opened.

--- a/scripts/retire.sh
+++ b/scripts/retire.sh
@@ -124,7 +124,7 @@ for login in *; do
   if [[ -n "$prInfo" ]]; then
     # If there is a PR already
     prNumber=$(jq .number <<< "$prInfo")
-    epochCreatedAt=$(date --date="$(jq -r .created_at <<< "$prInfo")" +%s)
+    epochCreatedAt=$(jq '.created_at | fromdateiso8601' <<< "$prInfo")
     if jq -e .draft <<< "$prInfo" >/dev/null && (( epochCreatedAt < noticeCutoff )); then
       log "$login has a retirement PR due, unmarking PR as draft and commenting with next steps"
       effect gh pr ready --repo "$ORG/$MEMBER_REPO" "$prNumber"


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs-committers/issues/42 by implementing https://github.com/NixOS/nixpkgs-committers/issues/42#issuecomment-3353067047: Only retire a user if they don't have a recently closed retirement PR.

This was tested according to the updated test instructions.