### PR TITLE
Remove Nixpkgs core team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @infinisil
-/members @NixOS/nixpkgs-core
+/members

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ This repository publicly tracks the [current members](./members) and [changes](.
 of the [Nixpkgs Committers](https://github.com/orgs/nixos/teams/nixpkgs-committers) team,
 whose members have write access to [Nixpkgs](https://github.com/nixos/nixpkgs).
 
-The [Nixpkgs core team](https://github.com/NixOS/org/blob/main/doc/nixpkgs-core.md)
-maintain the member list in this repository according to the [documented procedures](https://github.com/NixOS/org/blob/main/doc/nixpkgs-committers.md).
-
 ## Nominations
 
 To nominate yourself or somebody else:


### PR DESCRIPTION
The Nixpkgs core team [has disbanded](https://github.com/NixOS/org/pull/277).